### PR TITLE
Bump build number of erfa 1.7.3 to fix missing linux packages

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 6cf3a645d63e0c575a357797903eac5d2c6591d7cdb89217c8c4d39777cf18cb
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<3.6]
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
Probably due to the conda cdn outage, the linux packages of the build1 are still missing.

It was recommended to push another build just bumping the the version number.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
